### PR TITLE
change template manager logic, simplify config, rename options interface

### DIFF
--- a/DependencyInjection/EmailEngineConfiguration.php
+++ b/DependencyInjection/EmailEngineConfiguration.php
@@ -121,7 +121,8 @@ class EmailEngineConfiguration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('templates')
-                    ->scalarPrototype()->isRequired()->end()
+                    ->defaultValue([])
+                    ->scalarPrototype()->end()
                 ->end()
             ->end();
     }

--- a/Example/Attachments/TestImage.php
+++ b/Example/Attachments/TestImage.php
@@ -2,7 +2,7 @@
 
 namespace SfCod\EmailEngineBundle\Example\Attachments;
 
-use SfCod\EmailEngineBundle\Example\TestOptions;
+use SfCod\EmailEngineBundle\Example\TestTemplateOptions;
 use SfCod\EmailEngineBundle\Template\Attachments\AbstractAttachment;
 
 /**
@@ -12,7 +12,7 @@ use SfCod\EmailEngineBundle\Template\Attachments\AbstractAttachment;
  *
  * @package SfCod\EmailEngineBundle\Example\Attachments
  *
- * @property TestOptions $options
+ * @property TestTemplateOptions $options
  */
 class TestImage extends AbstractAttachment
 {

--- a/Example/Params/TestMessage.php
+++ b/Example/Params/TestMessage.php
@@ -2,8 +2,8 @@
 
 namespace SfCod\EmailEngineBundle\Example\Params;
 
-use SfCod\EmailEngineBundle\Example\TestOptions;
-use SfCod\EmailEngineBundle\Template\OptionsInterface;
+use SfCod\EmailEngineBundle\Example\TestTemplateOptions;
+use SfCod\EmailEngineBundle\Template\TemplateOptionsInterface;
 use SfCod\EmailEngineBundle\Template\Params\AbstractParameter;
 
 /**
@@ -28,11 +28,11 @@ class TestMessage extends AbstractParameter
     /**
      * Get parameter value
      *
-     * @param TestOptions|OptionsInterface $options
+     * @param TestTemplateOptions|TemplateOptionsInterface $options
      *
      * @return mixed
      */
-    public function getValue(OptionsInterface $options)
+    public function getValue(TemplateOptionsInterface $options)
     {
         return '<b>' . $options->message . '</b>';
     }

--- a/Example/TestTemplateOptions.php
+++ b/Example/TestTemplateOptions.php
@@ -2,7 +2,7 @@
 
 namespace SfCod\EmailEngineBundle\Example;
 
-use SfCod\EmailEngineBundle\Template\OptionsInterface;
+use SfCod\EmailEngineBundle\Template\TemplateOptionsInterface;
 
 /**
  * Class TestArguments
@@ -11,7 +11,7 @@ use SfCod\EmailEngineBundle\Template\OptionsInterface;
  *
  * @package SfCod\EmailEngineBundle\Example
  */
-class TestOptions implements OptionsInterface
+class TestTemplateOptions implements TemplateOptionsInterface
 {
     /**
      * @var string

--- a/Mailer/TemplateManager.php
+++ b/Mailer/TemplateManager.php
@@ -26,11 +26,13 @@ class TemplateManager
     /**
      * TemplateManager constructor.
      *
-     * @param array $templates
+     * @param TemplateInterface[] $templates
      */
     public function __construct(array $templates)
     {
-        $this->templates = $templates;
+        foreach($templates as $template) {
+            $this->templates[$template::getSlug()] = $template;
+        }
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ sfcod_email_engine:
                 class: SfCod\EmailEngineBundle\Repository\DbRepository
                 arguments: { entity: Common\Shared\Entity\Email, attribute: slug }
     templates:
-        test_template: SfCod\EmailEngineBundle\Example\TestTemplate
+        - SfCod\EmailEngineBundle\Example\TestTemplate
 ```
 
 Where "templates" section needed for "SfCod\EmailEngineBundle\Mailer\TemplateManager" service.

--- a/Template/AbstractTemplate.php
+++ b/Template/AbstractTemplate.php
@@ -31,7 +31,7 @@ abstract class AbstractTemplate implements TemplateInterface, RepositoryAwareInt
     /**
      * Template options
      *
-     * @var OptionsInterface
+     * @var TemplateOptionsInterface
      */
     protected $options;
 
@@ -45,9 +45,9 @@ abstract class AbstractTemplate implements TemplateInterface, RepositoryAwareInt
     /**
      * AbstractTemplate constructor.
      *
-     * @param OptionsInterface $options
+     * @param TemplateOptionsInterface $options
      */
-    public function __construct(OptionsInterface $options)
+    public function __construct(TemplateOptionsInterface $options)
     {
         $this->options = $options;
     }

--- a/Template/Attachments/AbstractAttachment.php
+++ b/Template/Attachments/AbstractAttachment.php
@@ -2,7 +2,7 @@
 
 namespace SfCod\EmailEngineBundle\Template\Attachments;
 
-use SfCod\EmailEngineBundle\Template\OptionsInterface;
+use SfCod\EmailEngineBundle\Template\TemplateOptionsInterface;
 
 /**
  * Class AbstractAttachment
@@ -14,16 +14,16 @@ use SfCod\EmailEngineBundle\Template\OptionsInterface;
 abstract class AbstractAttachment implements AttachmentInterface
 {
     /**
-     * @var OptionsInterface
+     * @var TemplateOptionsInterface
      */
     protected $options;
 
     /**
      * AttachmentInterface constructor.
      *
-     * @param OptionsInterface $options
+     * @param TemplateOptionsInterface $options
      */
-    public function __construct(OptionsInterface $options)
+    public function __construct(TemplateOptionsInterface $options)
     {
         $this->options = $options;
     }

--- a/Template/Attachments/AttachmentInterface.php
+++ b/Template/Attachments/AttachmentInterface.php
@@ -2,7 +2,7 @@
 
 namespace SfCod\EmailEngineBundle\Template\Attachments;
 
-use SfCod\EmailEngineBundle\Template\OptionsInterface;
+use SfCod\EmailEngineBundle\Template\TemplateOptionsInterface;
 
 /**
  * Email attachment interface
@@ -16,9 +16,9 @@ interface AttachmentInterface
     /**
      * AttachmentInterface constructor.
      *
-     * @param OptionsInterface $options
+     * @param TemplateOptionsInterface $options
      */
-    public function __construct(OptionsInterface $options);
+    public function __construct(TemplateOptionsInterface $options);
 
     /**
      * Get attachment name

--- a/Template/Params/ParameterInterface.php
+++ b/Template/Params/ParameterInterface.php
@@ -2,7 +2,7 @@
 
 namespace SfCod\EmailEngineBundle\Template\Params;
 
-use SfCod\EmailEngineBundle\Template\OptionsInterface;
+use SfCod\EmailEngineBundle\Template\TemplateOptionsInterface;
 
 /**
  * Template parameter interface
@@ -30,9 +30,9 @@ interface ParameterInterface
     /**
      * Get parameter value
      *
-     * @param OptionsInterface $options
+     * @param TemplateOptionsInterface $options
      *
      * @return mixed
      */
-    public function getValue(OptionsInterface $options);
+    public function getValue(TemplateOptionsInterface $options);
 }

--- a/Template/TemplateInterface.php
+++ b/Template/TemplateInterface.php
@@ -29,9 +29,9 @@ interface TemplateInterface
     /**
      * TemplateInterface constructor.
      *
-     * @param OptionsInterface $options
+     * @param TemplateOptionsInterface $options
      */
-    public function __construct(OptionsInterface $options);
+    public function __construct(TemplateOptionsInterface $options);
 
     /**
      * Get template priority

--- a/Template/TemplateOptionsInterface.php
+++ b/Template/TemplateOptionsInterface.php
@@ -9,6 +9,6 @@ namespace SfCod\EmailEngineBundle\Template;
  *
  * @package SfCod\EmailEngineBundle\Argument
  */
-interface OptionsInterface
+interface TemplateOptionsInterface
 {
 }


### PR DESCRIPTION
I've changed config by removing slugs' names from template manager, now they selects from templates ::getSlug() method. Also renamed options interface and updated readme.